### PR TITLE
Add regression test for collector depth guard and clean up timing code

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt, thread::ThreadId, time::Duration};
 use tracing::{
     span::{self},
-    Id, Subscriber, warn,
+    warn, Id, Subscriber,
 };
 use tracing_subscriber::{
     layer::Context,
@@ -244,7 +244,8 @@ where
         if let Some(parent) = span.parent() {
             let mut extensions = parent.extensions_mut();
             if let Some(timing_info) = extensions.get_mut::<SpanTimingInfo>() {
-                if let Some(thread_info) = timing_info.per_thread.get(&std::thread::current().id()) {
+                if let Some(thread_info) = timing_info.per_thread.get(&std::thread::current().id())
+                {
                     let last_enter_own = thread_info.last_enter_own;
                     let delta = self.clock.delta(last_enter_own, leave_parent);
                     timing_info.sum_own += delta;
@@ -254,7 +255,7 @@ where
 
         let mut extensions = span.extensions_mut();
         if let Some(timing_info) = extensions.get_mut::<SpanTimingInfo>() {
-            let mut per_thread = timing_info
+            let per_thread = timing_info
                 .per_thread
                 .entry(std::thread::current().id())
                 .or_default();
@@ -280,11 +281,11 @@ where
             timing_info.sum_with_children += wall_duration;
             let own_duration = self.clock.delta(per_thread.last_enter_own, end);
             timing_info.sum_own += own_duration;
-    
+
             // It is likely that we will be entered by the same thread again,
             // but we do not want to bloat memory if we are constantly entered
             // in different threads.
-            timing_info.per_thread.remove(&std::thread::current().id());    
+            timing_info.per_thread.remove(&std::thread::current().id());
         } else {
             // In on_enter we ensure that the per thread info exists -- so I don't exactly understand
             // when this can happen.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,9 +197,30 @@ impl CallTreeCollectorBuilder {
         H: FinishedCallTreeProcessor + 'static,
     {
         CallTreeCollector {
-            clock: self.clock.unwrap_or_else(Clock::new),
+            clock: self.clock.unwrap_or_default(),
             max_call_depth: core::cmp::max(2, self.max_call_depth),
             processor,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[derive(Default)]
+    struct NoopProcessor;
+
+    impl FinishedCallTreeProcessor for NoopProcessor {
+        fn process_finished_call(&self, _pool: CallPathPool) {}
+    }
+
+    #[test]
+    fn collector_enforces_minimum_depth() {
+        let collector = CallTreeCollectorBuilder::default()
+            .max_call_depth(0)
+            .build_with_collector(NoopProcessor);
+
+        assert_eq!(collector.max_call_depth, 2);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure `CallTreeCollectorBuilder` enforces the documented minimum `max_call_depth` and prevent regressions. 
- Clean up a small timing-path mutability warning reported by the toolchain and align with lint guidance for default construction.
- Attempt to update dependencies but external index/network issues prevented completing dependency upgrades.

### Description
- Replace `self.clock.unwrap_or_else(Clock::new)` with `self.clock.unwrap_or_default()` in `CallTreeCollectorBuilder::build_with_collector` to follow lint guidance while preserving behavior. 
- Remove an unnecessary `mut` binding in span enter timing code (`src/internal.rs`) to silence an `unused_mut` warning. 
- Add a unit test in `src/lib.rs` which builds a collector with `.max_call_depth(0)` and asserts the effective `max_call_depth` is clamped to `2`. 
- Minor formatting/whitespace cleanups applied via `cargo fmt`.

### Testing
- Ran `cargo fmt --all` successfully. 
- Ran `cargo test` and all unit and doc tests passed (`8` lib tests + `3` doc-tests), with no failures. 
- Ran `cargo clippy --all-targets --all-features` which completed and reported only unrelated future-incompatibility warnings for a third-party crate. 
- Attempted `cargo update` but it failed due to crates.io index/network access returning HTTP 403 in this environment, and `cargo update --offline` failed to resolve a yanked `futures-util 0.3.21` in offline mode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d55f0ab8dc8321a72cd9aae0c4d987)